### PR TITLE
Reduce number of writes to memory

### DIFF
--- a/External/External/main.c
+++ b/External/External/main.c
@@ -23,8 +23,8 @@ struct Color {
 
 void applyGlowEffect(uint32_t glowStartAddress, int glowObjectIndex, struct Color * color){
     bool stat = 1;
-	vm_write(csgo, glowStartAddress + 0x38 * glowObjectIndex + 0x24, (vm_offset_t) &stat, sizeof(bool));
-    vm_write(csgo, glowStartAddress + 0x38 * glowObjectIndex + 0x4, (vm_offset_t) &(color->red), sizeof(struct Color));
+    vm_write(csgo, glowStartAddress + 0x38 * glowObjectIndex + 0x24, (vm_offset_t) &stat, sizeof(bool));
+    vm_write(csgo, glowStartAddress + 0x38 * glowObjectIndex + 0x4, (vm_offset_t) &color, sizeof(struct Color));
 }
 
 void readPlayerPointAndHealth(mach_vm_address_t imgbase, uint32_t startAddress, int iTeamNum) {


### PR DESCRIPTION
I'm no expert in C and I don't use OSX, but I'm pretty sure this would work and would be more performant as it reduces the number of writes to memory.

If you create a class/struct for GlowObjectDefinition, you could write that to memory and reduce the number writes to just one per entity. Or if you want to refactor the cheat a bit, you could write a class that pushes multiple GlowObjectDefinitions to an array and then writes the whole array to memory at once, thus reducing the number of writes to just one for all entities.
